### PR TITLE
Fix GIssueMarkerView configuration example

### DIFF
--- a/content/documentation/rendering/content.md
+++ b/content/documentation/rendering/content.md
@@ -873,7 +873,7 @@ The issue marker element and its view are configured as follows:
 configureModelElement(
   context,
   DefaultTypes.ISSUE_MARKER,
-  SIssueMarker,
+  GIssueMarker,
   GIssueMarkerView
 );
 ```


### PR DESCRIPTION
The current example showing how to configure the GIssueMarkerView element uses the wrong instance of the target element. The right instance is GIssueMarker instead SIssueMarker